### PR TITLE
Add an OSX tip that helped me get started

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,8 +7,8 @@
    **OSX users:** You may need to start your Docker daemon with the command: 
 
   ```bash 
-  eval $(docker-machine env default)
   docker-machine start default 
+  eval $(docker-machine env default)
   ```
 
    before proceeding.

--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,16 @@
 ## Requirements
 1. [Docker](https://www.docker.com/)
   - Make sure you can successfully run docker commands without sudo. See [Ubuntu example](https://docs.docker.com/installation/ubuntulinux/#giving-non-root-access).
+  
+   **OSX users:** You may need to start your Docker daemon with the command: 
+
+  ```bash 
+  eval $(docker-machine env default)
+  docker-machine start default 
+  ```
+
+   before proceeding.
+   
 1. [Docker Compose](http://docs.docker.com/compose/)
 
 See also the [wiki](https://github.com/davenuman/bowline/wiki) for [platform-specific instructions](https://github.com/davenuman/bowline/wiki/Platform-specific-instructions).


### PR DESCRIPTION
Modify documentation to include a couple tips to get the docker daemon started after the initial installation. I found that it wasn't necessary use these commands after the initial installation.