### PR TITLE
Bugfix on get container name on compose 1.23.0+

### DIFF
--- a/lib/bowline/bowline
+++ b/lib/bowline/bowline
@@ -6,7 +6,9 @@ if [ -e "/proc/self/cgroup" ];then
 fi
 [ "$context" ] || export context="host"
 
-get_container_name () { echo "${SLUG}_${1}_1"; }
+get_container_name () {
+  docker-compose ps|grep "${SLUG}_${1}_1"|awk '{print $1}'
+}
 
 # Parses YML file and outputs key=value for each depth.
 # Usage: $(parse_yml filename prefix_to_add_to_key)


### PR DESCRIPTION
Docker Compose changed the naming of containers as mentioned in the
release notes:
https://docs.docker.com/release-notes/docker-compose/#1230-2018-10-30